### PR TITLE
feat: Change highlight color based on move color in Moves section

### DIFF
--- a/app.js
+++ b/app.js
@@ -814,11 +814,19 @@ Return ONLY the PGN format with comments after every move:`;
     highlightCurrentMove() {
         this.moveListElement.querySelectorAll('.move').forEach((el, index) => {
             if (index === this.currentMoveIndex) {
-                el.classList.add('current-move');
+                // Determine if this is a white move (even index) or black move (odd index)
+                const isWhiteMove = index % 2 === 0;
+                
+                if (isWhiteMove) {
+                    el.classList.add('current-move-white');
+                } else {
+                    el.classList.add('current-move-black');
+                }
+                
                 // Scroll into view if needed
                 el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
             } else {
-                el.classList.remove('current-move');
+                el.classList.remove('current-move', 'current-move-white', 'current-move-black');
             }
         });
     }

--- a/styles.css
+++ b/styles.css
@@ -310,6 +310,18 @@ h1 {
     color: white;
 }
 
+.move.current-move-white {
+    background-color: white;
+    color: black;
+    border: 2px solid #333;
+}
+
+.move.current-move-black {
+    background-color: black;
+    color: white;
+    border: 2px solid #333;
+}
+
 .move.has-comment {
     font-weight: bold;
     border-bottom: 2px dotted #e67e22;


### PR DESCRIPTION
Implements the feature requested in issue #3:

- White moves now highlight with white background and black text
- Black moves now highlight with black background and white text
- Added new CSS classes .current-move-white and .current-move-black
- Modified highlightCurrentMove() to apply color-specific highlighting
- Maintains existing functionality while improving visual clarity

Resolves # issue #3

Generated with [Claude Code](https://claude.ai/code)