### PR TITLE
feat: Add flip board button to toggle board orientation

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ class PGNViewer {
         this.btnPrev = document.getElementById('btn-prev');
         this.btnNext = document.getElementById('btn-next');
         this.btnEnd = document.getElementById('btn-end');
+        this.btnFlip = document.getElementById('btn-flip');
         
         // Load saved settings and set initial values
         this.loadApiKey();
@@ -65,6 +66,7 @@ class PGNViewer {
         this.btnPrev.addEventListener('click', () => this.previousMove());
         this.btnNext.addEventListener('click', () => this.nextMove());
         this.btnEnd.addEventListener('click', () => this.goToEnd());
+        this.btnFlip.addEventListener('click', () => this.flipBoard());
         
         // Close modal on outside click
         this.pgnModal.addEventListener('click', (e) => {
@@ -859,6 +861,10 @@ Return ONLY the PGN format with comments after every move:`;
         this.btnPrev.disabled = this.currentMoveIndex < 0;
         this.btnNext.disabled = this.currentMoveIndex >= this.moves.length - 1;
         this.btnEnd.disabled = this.currentMoveIndex >= this.moves.length - 1;
+    }
+    
+    flipBoard() {
+        this.board.flip();
     }
     
     updateMoveComment() {

--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
                     <button id="btn-prev" title="Previous move">◀</button>
                     <button id="btn-next" title="Next move">▶</button>
                     <button id="btn-end" title="Go to end">⏭</button>
+                    <button id="btn-flip" title="Flip board">↕️</button>
                 </div>
                 
                 <div class="status" id="status"></div>


### PR DESCRIPTION
## Summary
- Added a flip board button (↕️) to the navigation controls
- Implemented functionality to toggle board orientation between white and black perspectives
- Users can now easily switch viewing angles during game analysis

## Test plan
- [x] Load a PGN file
- [x] Click the flip board button (↕️) in the navigation controls
- [x] Verify the board rotates 180 degrees
- [x] Confirm pieces and coordinates are displayed correctly from the flipped perspective
- [x] Test that game navigation (previous/next move) works correctly with flipped board
- [x] Verify the button is always enabled regardless of game state

🤖 Generated with [Claude Code](https://claude.ai/code)